### PR TITLE
ModuleRouter: support paths in BASE

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -433,6 +433,7 @@ The configuration parameters available:
 * `client_db_uri`: connection URI to MongoDB or Redis instance where the client data will be persistent, if it's not specified the clients list will be received from the `client_db_path`.
 * `client_db_path`: path to a file containing the client database in json format. It will only be used if `client_db_uri` is not set. If `client_db_uri` and `client_db_path` are not set, clients will only be stored in-memory (not suitable for production use).
 * `sub_hash_salt`: salt which is hashed into the `sub` claim. If it's not specified, SATOSA will generate a random salt on each startup, which means that users will get new `sub` value after every restart.
+* `sub_mirror_subject` (default: `No`): if this is set to `Yes` and SATOSA releases a public `sub` claim to the client, then the subject identifier received from the backend will be mirrored to the client. The default is to hash the public subject identifier with `sub_hash_salt`. Pairwise `sub` claims are always hashed.
 * `provider`: provider configuration information. MUST be configured, the following configuration are supported:
     * `response_types_supported` (default: `[id_token]`): list of all supported response types, see [Section 3 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#Authentication).
     * `subject_types_supported` (default: `[pairwise]`): list of all supported subject identifier types, see [Section 8 of OIDC Core](http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes)

--- a/src/satosa/backends/base.py
+++ b/src/satosa/backends/base.py
@@ -29,7 +29,7 @@ class BackendModule(object):
         self.auth_callback_func = auth_callback_func
         self.internal_attributes = internal_attributes
         self.converter = AttributeMapper(internal_attributes)
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/") if base_url else ""
         self.name = name
 
     def start_auth(self, context, internal_request):

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 
 from saml2.s_utils import UnknownSystemEntity
+from urllib.parse import urlparse
 
 from satosa import util
 from .context import Context
@@ -39,6 +40,8 @@ class SATOSABase(object):
         """
         self.config = config
 
+        base_path = urlparse(self.config["BASE"]).path.lstrip("/")
+
         logger.info("Loading backend modules...")
         backends = load_backends(self.config, self._auth_resp_callback_func,
                                  self.config["INTERNAL_ATTRIBUTES"])
@@ -64,8 +67,10 @@ class SATOSABase(object):
                                             self.config["BASE"]))
             self._link_micro_services(self.response_micro_services, self._auth_resp_finish)
 
-        self.module_router = ModuleRouter(frontends, backends,
-                                          self.request_micro_services + self.response_micro_services)
+        self.module_router = ModuleRouter(frontends,
+                                          backends,
+                                          self.request_micro_services + self.response_micro_services,
+                                          base_path)
 
     def _link_micro_services(self, micro_services, finisher):
         if not micro_services:

--- a/src/satosa/context.py
+++ b/src/satosa/context.py
@@ -76,10 +76,6 @@ class Context(object):
             raise ValueError("path can't start with '/'")
         self._path = p
 
-    def target_entity_id_from_path(self):
-        target_entity_id = self.path.split("/")[1]
-        return target_entity_id
-
     def decorate(self, key, value):
         """
         Add information to the context

--- a/src/satosa/frontends/base.py
+++ b/src/satosa/frontends/base.py
@@ -3,6 +3,9 @@ Holds a base class for frontend modules used in the SATOSA proxy.
 """
 from ..attribute_mapping import AttributeMapper
 
+import os.path
+from urllib.parse import urlparse
+
 
 class FrontendModule(object):
     """
@@ -23,8 +26,10 @@ class FrontendModule(object):
         self.auth_req_callback_func = auth_req_callback_func
         self.internal_attributes = internal_attributes
         self.converter = AttributeMapper(internal_attributes)
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/") if base_url else ""
         self.name = name
+        self.endpoint_baseurl = os.path.join(self.base_url, self.name)
+        self.endpoint_basepath = urlparse(self.endpoint_baseurl).path.lstrip("/")
 
     def handle_authn_response(self, context, internal_resp):
         """

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -46,6 +46,11 @@ from satosa.internal import InternalData
 logger = logging.getLogger(__name__)
 
 
+class MirrorPublicSubjectIdentifierFactory(HashBasedSubjectIdentifierFactory):
+    def create_public_identifier(self, user_id):
+        return user_id
+
+
 class OpenIDConnectFrontend(FrontendModule):
     """
     A OpenID Connect frontend module
@@ -75,7 +80,10 @@ class OpenIDConnectFrontend(FrontendModule):
         )
 
         sub_hash_salt = self.config.get("sub_hash_salt", rndstr(16))
-        authz_state = _init_authorization_state(provider_config, db_uri, sub_hash_salt)
+        mirror_public = self.config.get("sub_mirror_public", False)
+        authz_state = _init_authorization_state(
+            provider_config, db_uri, sub_hash_salt, mirror_public
+        )
 
         client_db_uri = self.config.get("client_db_uri")
         cdb_file = self.config.get("client_db_path")
@@ -459,7 +467,7 @@ def _create_provider(
     return provider
 
 
-def _init_authorization_state(provider_config, db_uri, sub_hash_salt):
+def _init_authorization_state(provider_config, db_uri, sub_hash_salt, mirror_public):
     if db_uri:
         authz_code_db = StorageBase.from_uri(
             db_uri,
@@ -498,8 +506,14 @@ def _init_authorization_state(provider_config, db_uri, sub_hash_salt):
         ]
         if k in provider_config
     }
+
+    subject_id_factory = (
+        MirrorPublicSubjectIdentifierFactory(sub_hash_salt)
+        if mirror_public
+        else HashBasedSubjectIdentifierFactory(sub_hash_salt)
+    )
     return AuthorizationState(
-        HashBasedSubjectIdentifierFactory(sub_hash_salt),
+        subject_id_factory,
         authz_code_db,
         access_token_db,
         refresh_token_db,

--- a/src/satosa/frontends/openid_connect.py
+++ b/src/satosa/frontends/openid_connect.py
@@ -89,7 +89,6 @@ class OpenIDConnectFrontend(FrontendModule):
         else:
             cdb = {}
 
-        self.endpoint_baseurl = "{}/{}".format(self.base_url, self.name)
         self.provider = _create_provider(
             provider_config,
             self.endpoint_baseurl,
@@ -165,6 +164,9 @@ class OpenIDConnectFrontend(FrontendModule):
         :rtype: list[(str, ((satosa.context.Context, Any) -> satosa.response.Response, Any))]
         :raise ValueError: if more than one backend is configured
         """
+        provider_config = ("^.well-known/openid-configuration$", self.provider_config)
+        jwks_uri = ("^{}/jwks$".format(self.endpoint_basepath), self.jwks)
+
         backend_name = None
         if len(backend_names) != 1:
             # only supports one backend since there currently is no way to publish multiple authorization endpoints
@@ -181,16 +183,13 @@ class OpenIDConnectFrontend(FrontendModule):
         else:
             backend_name = backend_names[0]
 
-        provider_config = ("^.well-known/openid-configuration$", self.provider_config)
-        jwks_uri = ("^{}/jwks$".format(self.name), self.jwks)
-
         if backend_name:
             # if there is only one backend, include its name in the path so the default routing can work
             auth_endpoint = "{}/{}/{}/{}".format(self.base_url, backend_name, self.name, AuthorizationEndpoint.url)
             self.provider.configuration_information["authorization_endpoint"] = auth_endpoint
             auth_path = urlparse(auth_endpoint).path.lstrip("/")
         else:
-            auth_path = "{}/{}".format(self.name, AuthorizationEndpoint.url)
+            auth_path = "{}/{}".format(self.endpoint_basepath, AuthorizationEndpoint.url)
 
         authentication = ("^{}$".format(auth_path), self.handle_authn_request)
         url_map = [provider_config, jwks_uri, authentication]
@@ -200,7 +199,7 @@ class OpenIDConnectFrontend(FrontendModule):
                 self.endpoint_baseurl, TokenEndpoint.url
             )
             token_endpoint = (
-                "^{}/{}".format(self.name, TokenEndpoint.url), self.token_endpoint
+                "^{}/{}".format(self.endpoint_basepath, TokenEndpoint.url), self.token_endpoint
             )
             url_map.append(token_endpoint)
 
@@ -208,13 +207,13 @@ class OpenIDConnectFrontend(FrontendModule):
                 "{}/{}".format(self.endpoint_baseurl, UserinfoEndpoint.url)
             )
             userinfo_endpoint = (
-                "^{}/{}".format(self.name, UserinfoEndpoint.url), self.userinfo_endpoint
+                "^{}/{}".format(self.endpoint_basepath, UserinfoEndpoint.url), self.userinfo_endpoint
             )
             url_map.append(userinfo_endpoint)
 
         if "registration_endpoint" in self.provider.configuration_information:
             client_registration = (
-                "^{}/{}".format(self.name, RegistrationEndpoint.url),
+                "^{}/{}".format(self.endpoint_basepath, RegistrationEndpoint.url),
                 self.client_registration,
             )
             url_map.append(client_registration)

--- a/src/satosa/frontends/ping.py
+++ b/src/satosa/frontends/ping.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 
 import satosa.logging_util as lu
 import satosa.micro_services.base
@@ -44,7 +45,7 @@ class PingFrontend(satosa.frontends.base.FrontendModule):
         :rtype: list[(str, ((satosa.context.Context, Any) -> satosa.response.Response, Any))]
         :raise ValueError: if more than one backend is configured
         """
-        url_map = [("^{}".format(self.name), self.ping_endpoint)]
+        url_map = [("^{}".format(os.path.join(self.endpoint_basepath, self.name)), self.ping_endpoint)]
 
         return url_map
 

--- a/src/satosa/frontends/saml2.py
+++ b/src/satosa/frontends/saml2.py
@@ -117,7 +117,7 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
 
         if self.enable_metadata_reload():
             url_map.append(
-                ("^%s/%s$" % (self.name, "reload-metadata"), self._reload_metadata))
+                ("^%s/%s$" % (self.endpoint_basepath, "reload-metadata"), self._reload_metadata))
 
         self.idp_config = self._build_idp_config_endpoints(
             self.config[self.KEY_IDP_CONFIG], backend_names)
@@ -512,15 +512,19 @@ class SAMLFrontend(FrontendModule, SAMLBaseModule):
         """
         url_map = []
 
+        backend_providers = "|".join(providers)
+        base_path = urlparse(self.base_url).path.lstrip("/")
+        if base_path:
+            base_path = base_path + "/"
         for endp_category in self.endpoints:
             for binding, endp in self.endpoints[endp_category].items():
-                valid_providers = ""
-                for provider in providers:
-                    valid_providers = "{}|^{}".format(valid_providers, provider)
-                valid_providers = valid_providers.lstrip("|")
-                parsed_endp = urlparse(endp)
-                url_map.append(("(%s)/%s$" % (valid_providers, parsed_endp.path),
-                                functools.partial(self.handle_authn_request, binding_in=binding)))
+                endp_path = urlparse(endp).path
+                url_map.append(
+                    (
+                        "^{}({})/{}$".format(base_path, backend_providers, endp_path),
+                        functools.partial(self.handle_authn_request, binding_in=binding)
+                    )
+                )
 
         if self.expose_entityid_endpoint():
             logger.debug("Exposing frontend entity endpoint = {}".format(self.idp.config.entityid))
@@ -676,10 +680,17 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :param context:
         :return: An idp server
         """
-        target_entity_id = context.target_entity_id_from_path()
+        target_entity_id = self._target_entity_id_from_path(context.path)
         idp_conf_file = self._load_endpoints_to_config(context.target_backend, target_entity_id)
         idp_config = IdPConfig().load(idp_conf_file)
         return Server(config=idp_config)
+
+    def _target_entity_id_from_path(self, request_path):
+        path = request_path.lstrip("/")
+        base_path = urlparse(self.base_url).path.lstrip("/")
+        if base_path and path.startswith(base_path):
+            path = path[len(base_path):].lstrip("/")
+        return path.split("/")[1]
 
     def _load_idp_dynamic_entity_id(self, state):
         """
@@ -706,7 +717,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :type binding_in: str
         :rtype: satosa.response.Response
         """
-        target_entity_id = context.target_entity_id_from_path()
+        target_entity_id = self._target_entity_id_from_path(context.path)
         target_entity_id = urlsafe_b64decode(target_entity_id).decode()
         context.decorate(Context.KEY_TARGET_ENTITYID, target_entity_id)
 
@@ -724,7 +735,7 @@ class SAMLMirrorFrontend(SAMLFrontend):
         :rtype: dict[str, dict[str, str] | str]
         """
         state = super()._create_state_data(context, resp_args, relay_state)
-        state["target_entity_id"] = context.target_entity_id_from_path()
+        state["target_entity_id"] = self._target_entity_id_from_path(context.path)
         return state
 
     def handle_backend_error(self, exception):
@@ -759,13 +770,16 @@ class SAMLMirrorFrontend(SAMLFrontend):
         """
         url_map = []
 
+        backend_providers = "|".join(providers)
+        base_path = urlparse(self.base_url).path.lstrip("/")
+        if base_path:
+            base_path = base_path + "/"
         for endp_category in self.endpoints:
             for binding, endp in self.endpoints[endp_category].items():
-                valid_providers = "|^".join(providers)
-                parsed_endp = urlparse(endp)
+                endp_path = urlparse(endp).path
                 url_map.append(
                     (
-                        r"(^{})/\S+/{}".format(valid_providers, parsed_endp.path),
+                        "^{}({})/\S+/{}$".format(base_path, backend_providers, endp_path),
                         functools.partial(self.handle_authn_request, binding_in=binding)
                     )
                 )

--- a/src/satosa/micro_services/account_linking.py
+++ b/src/satosa/micro_services/account_linking.py
@@ -3,6 +3,7 @@ An account linking module for the satosa proxy
 """
 import json
 import logging
+import os.path
 
 import requests
 from jwkest.jwk import rsa_load, RSAKey
@@ -161,4 +162,13 @@ class AccountLinking(ResponseMicroService):
 
         :return: A list of endpoints bound to a function
         """
-        return [("^account_linking%s$" % self.endpoint, self._handle_al_response)]
+        return [
+            (
+                "^{}$".format(
+                    os.path.join(
+                        self.base_path, "account_linking", self.endpoint.lstrip("/")
+                    )
+                ),
+                self._handle_al_response,
+            )
+        ]

--- a/src/satosa/micro_services/base.py
+++ b/src/satosa/micro_services/base.py
@@ -2,6 +2,7 @@
 Micro service for SATOSA
 """
 import logging
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,7 @@ class MicroService(object):
     def __init__(self, name, base_url, **kwargs):
         self.name = name
         self.base_url = base_url
+        self.base_path = urlparse(base_url).path.lstrip("/")
         self.next = None
 
     def process(self, context, data):

--- a/src/satosa/micro_services/consent.py
+++ b/src/satosa/micro_services/consent.py
@@ -4,6 +4,7 @@ A consent module for the satosa proxy
 import hashlib
 import json
 import logging
+import os.path
 from base64 import urlsafe_b64encode
 
 import requests
@@ -238,4 +239,13 @@ class Consent(ResponseMicroService):
 
         :return: A list of endpoints bound to a function
         """
-        return [("^consent%s$" % self.endpoint, self._handle_consent_response)]
+        return [
+            (
+                "^{}$".format(
+                    os.path.join(
+                        self.base_path, "consent", self.endpoint.lstrip("/")
+                    )
+                ),
+                self._handle_consent_response,
+            )
+        ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from satosa.state import State
 from .util import create_metadata_from_config_dict
 from .util import generate_cert, write_cert
 
-BASE_URL = "https://test-proxy.com"
+BASE_URL = "https://test-proxy.com/satosa"
 
 
 @pytest.fixture(scope="session")
@@ -38,7 +38,7 @@ def cert_and_key(tmpdir):
 
 @pytest.fixture
 def sp_conf(cert_and_key):
-    sp_base = "http://example.com"
+    sp_base = "http://example.com/test"
     spconfig = {
         "entityid": "{}/unittest_sp.xml".format(sp_base),
         "service": {
@@ -64,7 +64,7 @@ def sp_conf(cert_and_key):
 
 @pytest.fixture
 def idp_conf(cert_and_key):
-    idp_base = "http://idp.example.com"
+    idp_base = "http://idp.example.com/test"
 
     idpconfig = {
         "entityid": "{}/{}/proxy.xml".format(idp_base, "Saml2IDP"),
@@ -138,7 +138,23 @@ def satosa_config_dict(backend_plugin_config, frontend_plugin_config, request_mi
         "BACKEND_MODULES": [backend_plugin_config],
         "FRONTEND_MODULES": [frontend_plugin_config],
         "MICRO_SERVICES": [request_microservice_config, response_microservice_config],
-        "LOGGING": {"version": 1}
+        "LOGGING": {
+            "version": 1,
+            "handlers": {
+                "stdout": {
+                    "level": "DEBUG",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "simple",
+                }
+            },
+            "loggers": {"satosa": {"level": "DEBUG"}},
+            "formatters": {
+                "simple": {
+                    "format": "[%(asctime)s] [%(levelname)s] [%(name)s.%(funcName)s] %(message)s"
+                }
+            },
+        }
     }
     return config
 

--- a/tests/flows/test_account_linking.py
+++ b/tests/flows/test_account_linking.py
@@ -1,4 +1,6 @@
+import os.path
 import responses
+from urllib.parse import urlparse
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
@@ -13,6 +15,7 @@ class TestAccountLinking:
         account_linking_module_config["config"]["api_url"] = api_url
         account_linking_module_config["config"]["redirect_url"] = redirect_url
         satosa_config_dict["MICRO_SERVICES"].insert(0, account_linking_module_config)
+        base_path = urlparse(satosa_config_dict["BASE"]).path.lstrip("\n")
 
         # application
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), Response)
@@ -36,5 +39,5 @@ class TestAccountLinking:
             rsps.add(responses.GET, "{}/get_id".format(api_url), "test_userid", status=200)
 
             # incoming account linking response
-            http_resp = test_client.get("/account_linking/handle_account_linking")
+            http_resp = test_client.get(os.path.join("/", base_path, "account_linking/handle_account_linking"))
             assert http_resp.status_code == 200

--- a/tests/flows/test_consent.py
+++ b/tests/flows/test_consent.py
@@ -1,7 +1,9 @@
 import json
+import os.path
 import re
 
 import responses
+from urllib.parse import urlparse
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
@@ -16,6 +18,7 @@ class TestConsent:
         consent_module_config["config"]["api_url"] = api_url
         consent_module_config["config"]["redirect_url"] = redirect_url
         satosa_config_dict["MICRO_SERVICES"].append(consent_module_config)
+        base_path = urlparse(satosa_config_dict["BASE"]).path.lstrip("\n")
 
         # application
         test_client = Client(make_app(SATOSAConfig(satosa_config_dict)), Response)
@@ -43,5 +46,5 @@ class TestConsent:
             rsps.add(responses.GET, verify_url_re, json.dumps({"foo": "bar"}), status=200)
 
             # incoming consent response
-            http_resp = test_client.get("/consent/handle_consent")
+            http_resp = test_client.get(os.path.join("/", base_path, "consent/handle_consent"))
             assert http_resp.status_code == 200

--- a/tests/satosa/frontends/test_openid_connect.py
+++ b/tests/satosa/frontends/test_openid_connect.py
@@ -402,6 +402,27 @@ class TestOpenIDConnectFrontend(object):
         provider_info = ProviderConfigurationResponse().deserialize(frontend.provider_config(None).message, "json")
         assert ("registration_endpoint" in provider_info) == client_registration_enabled
 
+    @pytest.mark.parametrize("sub_mirror_public", [
+        True,
+        False
+    ])
+    def test_mirrored_subject(self, context, frontend_config, authn_req, sub_mirror_public):
+        frontend_config["sub_mirror_public"] = sub_mirror_public
+        frontend_config["provider"]["subject_types_supported"] = ["public"]
+        frontend = self.create_frontend(frontend_config)
+
+        self.insert_client_in_client_db(frontend, authn_req["redirect_uri"])
+        internal_response = self.setup_for_authn_response(context, frontend, authn_req)
+        http_resp = frontend.handle_authn_response(context, internal_response)
+
+        resp = AuthorizationResponse().deserialize(urlparse(http_resp.message).fragment)
+        id_token = IdToken().from_jwt(resp["id_token"], key=[frontend.signing_key])
+        assert "sub" in id_token
+        if sub_mirror_public:
+            assert id_token["sub"] == OIDC_USERS["testuser1"]["eduPersonTargetedID"][0]
+        else:
+            assert id_token["sub"] != OIDC_USERS["testuser1"]["eduPersonTargetedID"][0]
+
     def test_token_endpoint(self, context, frontend_config, authn_req):
         token_lifetime = 60 * 60 * 24
         frontend_config["provider"]["access_token_lifetime"] = token_lifetime


### PR DESCRIPTION
If Satosa is installed under a path which is not the root of the
webserver (ie. "https://example.com/satosa"), then endpoint routing must
take the base path into consideration.

Some modules registered some of their endpoints with the base path
included, but other times the base path was omitted, thus it made the
routing fail. Now all endpoint registrations include the base path in
their endpoint map.

Additionally, DEBUG logging was configured for the tests so that the
debug logs are accessible during testing.

### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


